### PR TITLE
Rename status parameter to orderStatus for getOrders function

### DIFF
--- a/src/lib/clients/rest.ts
+++ b/src/lib/clients/rest.ts
@@ -284,7 +284,7 @@ export class RestClient implements REST {
       limit,
       beforeId,
       afterId,
-      status,
+      orderStatus,
       orderType,
     } = params
 
@@ -310,8 +310,8 @@ export class RestClient implements REST {
     if (afterId) {
       url += `after_id=${afterId}&`
     }
-    if (status) {
-      url += `status=${status}&`
+    if (orderStatus) {
+      url += `order_status=${orderStatus}&`
     }
     if (orderType) {
       url += `order_type=${orderType}&`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -113,7 +113,7 @@ export interface GetOrdersGetterParams {
   limit?: number
   beforeId?: number
   afterId?: number
-  status?: string
+  orderStatus?: string
   orderType?: string
 }
 


### PR DESCRIPTION
* Rename `status` parameter under getOrders function to `orderStatus` to allow filtering by `order_status`