### PR TITLE
fix/add-zilpay-to-zilclient

### DIFF
--- a/src/lib/tradehub/clients/ZILClient.ts
+++ b/src/lib/tradehub/clients/ZILClient.ts
@@ -123,6 +123,19 @@ export class ZILClient {
             },
             zilliqa.provider,
         )
+
+        if (typeof window !== "undefined" && typeof (window as any).zilPay !== 'undefined') {
+            // sign and txn via zilpay
+            try {
+                const txn = await (window as any).zilPay.blockchain.createTransaction(tx)
+                tx.id = txn.ID
+                return tx
+            } catch (err) {
+                throw new Error(err)
+            }
+        }
+
+        // fallback to zilliqa sdk sign
         await signer.sign(tx)
         const response = await zilliqa.provider.send(RPCMethod.CreateTransaction, { ...tx.txParams })
         if (response.error !== undefined) {
@@ -227,7 +240,6 @@ export class ZILClient {
               ],
         }
 
-
         const tx = new Transaction(
             {
                 ...callParams,
@@ -236,14 +248,27 @@ export class ZILClient {
             },
             zilliqa.provider,
         )
-        await signer.sign(tx)
+
+        if (typeof window !== "undefined" && typeof (window as any).zilPay !== 'undefined') {
+            // sign and txn via zilpay
+            try {
+                const txn = await (window as any).zilPay.blockchain.createTransaction(tx)
+                tx.id = txn.ID
+                return tx
+            } catch (err) {
+                throw new Error(err)
+            }
+        }
+
+        // fallback to zilliqa sdk sign
+        await signer.sign(tx);
+
         const response = await zilliqa.provider.send(RPCMethod.CreateTransaction, { ...tx.txParams })
         if (response.error !== undefined) {
             throw new Error(response.error.message)
         }
         tx.id = response.result.TranID
         return tx
-
     }
 
     /**
@@ -276,5 +301,3 @@ export class ZILClient {
         return this.getConfig().LockProxyAddr;
     }
 }
-
-


### PR DESCRIPTION
### Description
- Include the ability to detect zilpay and sign the transaction when locking the amount on Zilliqa blockchain

### Why
`ZIlClient.ts` has a `signer` parameter of `ZILLockParam` type. The signer is initiated via ZilliqaJS SDK with a private key.

```
    const zilliqa = new Zilliqa(client.getProviderUrl())
    const wallet  = new Wallet(zilliqa.network.provider)
    wallet.addByPrivateKey(privateKey)

    // approve zrc2 (increase allowance)
    const approveZRC2Params: ApproveZRC2Params = {
        token: token,
        gasPrice: new BigNumber("2000000000"),
        gasLimit: new BigNumber(25000),
        zilAddress: address,
        signer: wallet,  <--- this signer
    }
```

However, when trying to use the `ZILClient` on `zilswap-webapp`, the developers has no way to retrieve the user's private key from ZilPay to initialize the `Zilliqa Wallet` object to create the required signer. As such, there is a requirement to include the ability to allow zilpay to sign the transaction from within `ZILClient.ts`