### PR TITLE
fix path of get_block_height_from_unix and missing order key in leaderboard model

### DIFF
--- a/src/lib/tradehub/api/spec/_rest_endpoints.ts
+++ b/src/lib/tradehub/api/spec/_rest_endpoints.ts
@@ -9,7 +9,7 @@ export const TradehubEndpoints = {
   'tradehub/get_tx_types': '/get_transaction_types',
   'tradehub/get_blocks': '/get_blocks',
   'tradehub/get_cosmos_block': '/blocks/:height',
-  'tradehub/get_block_height_from_unix': 'get_blockheight_from_unix',
+  'tradehub/get_block_height_from_unix': '/get_blockheight_from_unix',
   'tradehub/get_average_block_time': '/get_block_time',
   'tradehub/get_token': '/get_token',
   'tradehub/get_tokens': '/get_tokens',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -953,6 +953,7 @@ export interface GetLeaderboardResponse {
   to_block: string
   from_time: string
   to_time: string
+  order: string
 }
 
 export interface LeaderboardDataResponse {


### PR DESCRIPTION
fix path of get_block_height_from_unix and missing order key in leaderboard model