### PR TITLE
fix/remove-callamount

### DIFF
--- a/src/lib/tradehub/clients/ZILClient.ts
+++ b/src/lib/tradehub/clients/ZILClient.ts
@@ -264,11 +264,6 @@ export class ZILClient {
                   type: 'Uint256',
                   value: "0",
               },
-              {
-                  vname: 'callAmount',
-                  type: 'Uint256',
-                  value: "0",
-              },
         ]
 
         const data = {


### PR DESCRIPTION
- removed `callAmount` contract argument in `lock()`

**Notes**
Have to update zilswap to pull latest when merged